### PR TITLE
Updated check_update() method to only update version option when version...

### DIFF
--- a/gravity-forms-highrise-crm.php
+++ b/gravity-forms-highrise-crm.php
@@ -120,13 +120,15 @@ class GFHighriseCRM {
 	}
 
 	public static function check_update($update_plugins_option){
-		if ( get_option( 'gf_highrise_crm_version' ) != self::$version ) {
-			require_once( 'inc/data.php' );
-			GFHighriseCRMData::update_table();
-		}
+        
+        if ( get_option( 'gf_highrise_crm_version' ) != self::$version ) {
+            require_once( 'inc/data.php' );
+            GFHighriseCRMData::update_table();
+            update_option( 'gf_highrise_crm_version', self::$version );
+        }
 
-		update_option( 'gf_highrise_crm_version', self::$version );
-	}
+        return $update_plugins_option;
+    }
 
 	private static function get_key(){
 		if(self::is_gravityforms_supported())


### PR DESCRIPTION
... is different and to return the filtered variable

Not returning the filtered variable ($update_plugin_option) was causing
an issue with my EDD-powered plugin which hooks to the
"pre_set_site_transient_update_plugins" filter. This filter is typically
only fired when there is a change to the value of the update_plugins
transient. The check_update function was not returning any value so the
pre_set_site_transient filter was firing on every page load.
